### PR TITLE
Fix versionId placeholder in API requests

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -265,7 +265,7 @@ Api.prototype = {
     authorize: function(callback) {
         var self = this;
 
-        return this.client.methods.authentication_oauth({
+        return this.client.methods.authentication_oauth(_.extend({}, this.requestOptions, {
             data: {
                 grant_type: 'client_credentials'
             },
@@ -273,7 +273,7 @@ Api.prototype = {
                 'Authorization': _getBasicAuthHash(this.config.clientId, this.config.clientPassword),
                 'Content-Type': 'application/x-www-form-urlencoded'
             }
-        }, function(data) {
+        }), function(data) {
             _.extend(self.requestOptions.headers, {
                 Authorization: data.token_type + ' ' + data.access_token
             });


### PR DESCRIPTION
Authentication request was not re-using the requestOptions values, that contain the path variables to be replaced, such as API versionId