### PR TITLE
Fix typings

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -261,8 +261,8 @@ declare namespace MangoPay {
   type WithToJson<T extends object> = T & { toJSON(): any };
 
   // Determines the shape of the response
-  interface ReadResponseHeaders {
-    readResponseHeaders: true;
+  interface resolveWithFullResponse {
+    resolveWithFullResponse: true;
   }
 
   interface PaginationOptions {
@@ -302,11 +302,11 @@ declare namespace MangoPay {
   }
 
   interface MethodOptionWithResponse extends MethodOptions {
-    readResponseHeaders: true;
+    resolveWithFullResponse: true;
   }
 
   interface MethodOptionWithoutResponse extends MethodOptions {
-    readResponseHeaders?: false;
+    resolveWithFullResponse?: false;
   }
 
   interface DependsObject {
@@ -1850,7 +1850,7 @@ declare namespace MangoPay {
       /**
        * This is the URL where to redirect users to proceed to 3D secure validation
        */
-      SecureModeRedirectUrl: string;
+      SecureModeRedirectURL: string;
 
       /**
        * This is the URL where users are automatically redirected after 3D secure validation (if activated)
@@ -2673,7 +2673,7 @@ declare namespace MangoPay {
       /**
        * This is the URL where to redirect users to proceed to 3D secure validation
        */
-      SecureModeRedirectUrl: string;
+      SecureModeRedirectURL: string;
     }
 
     interface CreateCardDirectPayIn {

--- a/typings/mangopay2-nodejs-sdk-tests.ts
+++ b/typings/mangopay2-nodejs-sdk-tests.ts
@@ -54,7 +54,7 @@ api.Users.create(legalUser).then(data => {
   console.log(`${legalUser.Name} user created at ${legalUser.CreationDate}`);
 });
 
-api.Users.create(legalUser, { readResponseHeaders: true }).then(data => {
+api.Users.create(legalUser, { resolveWithFullResponse: true }).then(data => {
   const d = data; // $ExpectType WithResponse<UserLegalData>
   const value = data.body; // $ExpectType UserLegalData
 });


### PR DESCRIPTION
Some Typescript types are not matching their Javascript targets:
JS -> TS
`SecureModeRedirectURL `-> `SecureModeRedirectUrl`
`resolveWithFullResponse `-> `readResponseHeaders`

This pull request fix them.