### PR TITLE
added typing function getById UboDeclaration

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3761,6 +3761,13 @@ declare namespace MangoPay {
     get: TwoArgsMethodOverload<string, string, uboDeclaration.UboDeclarationData>;
 
     /**
+     * Retrieves a UBO declaration object from the API.
+     * @param {String} id Unique identifier
+     * @param {Object} options
+     */
+    getById: MethodOverload<string, uboDeclaration.UboDeclarationData>;
+
+    /**
      * Updates a UBO declaration entity.
      * @param {String} userId User Unique Identifier
      * @param {Object} uboDeclaration Updated UBO declaration entity - must have ID!


### PR DESCRIPTION
A method has been added to get a declaration only by its id (not requiring userId).

The README `docs/UboDeclarations.md` and `lib/services/UboDeclarations.js` have been updated but the typings file was missing an update.

In my project whenever I call the `getById` method, I get

```
Property 'getById' does not exist on type 'UboDeclarations'
```