### PR TITLE
Adding address type for direct bank wires response

### DIFF
--- a/typings/models/payIn.d.ts
+++ b/typings/models/payIn.d.ts
@@ -8,6 +8,7 @@ import { base } from "../base";
 import { money } from "./money";
 import { securityInfo } from "./securityInfo";
 import { shipping } from "./shipping";
+import { address } from "./address";
 
 export namespace payIn {
     import BillingData = billing.BillingData;
@@ -776,7 +777,7 @@ export namespace payIn {
         /**
          * The address of the owner of the bank account
          */
-        OwnerAddress: string;
+        OwnerAddress: address.AddressType;
 
         /**
          * The type of bank account


### PR DESCRIPTION
The response is an object, not a string. This just matches back to the correct type so it doesn't break my TS compile.