### PR TITLE
Typo mistake reports_wallets_create instead of reports_wallet_create

### DIFF
--- a/lib/apiMethods.js
+++ b/lib/apiMethods.js
@@ -142,7 +142,7 @@ module.exports = {
     "disputes_pending_settlement": ["/${apiVersion}/${clientId}/disputes/pendingsettlement", "GET"],
 
     "reports_transactions_create": ["/${apiVersion}/${clientId}/reports/transactions/", "POST"],
-    "reports_wallets_create": ["/${apiVersion}/${clientId}/reports/wallets/", "POST"],
+    "reports_wallet_create": ["/${apiVersion}/${clientId}/reports/wallets/", "POST"],
     "reports_get": ["/${apiVersion}/${clientId}/reports/${id}", "GET"],
     "reports_all": ["/${apiVersion}/${clientId}/reports", "GET"],
 

--- a/typings/types.d.ts
+++ b/typings/types.d.ts
@@ -128,7 +128,7 @@ export type ApiMethod =
     | "disputes_repudiation_get_settlement"
     | "disputes_pending_settlement"
     | "reports_transactions_create"
-    | "reports_wallets_create"
+    | "reports_wallet_create"
     | "reports_get"
     | "reports_all"
     | "mandates_directdebit-web_create"


### PR DESCRIPTION
When I call mangopay.Reports.create(report) it uses the method reports_wallet_create which does not exists, I found there's a method called reports_wallets_create (with an extra s at wallet) maybe this was the one supposed to be called