### PR TITLE
Add the missing PaymentStatus for the deposit

### DIFF
--- a/typings/enums.d.ts
+++ b/typings/enums.d.ts
@@ -176,6 +176,13 @@ export namespace enums {
     interface IPaymentStatus {
         Waiting: "WAITING";
         Canceled: "CANCELED";
+        CancelRequested: "CANCEL_REQUESTED";
+        Expired: "EXPIRED";
+        ToBeCompleted: "TO_BE_COMPLETED";
+        NoShowRequested: "NO_SHOW_REQUESTED";
+        NoShow: "NO_SHOW";
+        Validated: "VALIDATED";
+        Failed: "FAILED";
     }
 
     interface IShippingPreference {


### PR DESCRIPTION
I'm working on an application that implements the 30-day preauthorization flow.
I noticed that the `PaymentStatus` enum doesn't report all the values stated in the documentation:

https://docs.mangopay.com/api-reference/deposit-preauthorizations/create-deposit-preauthorization#param-payment-status

With this PR, I added the missing values