### PR TITLE
Add StatementDescriptor to Refund and Apple Pay PayIn

### DIFF
--- a/lib/models/Refund.js
+++ b/lib/models/Refund.js
@@ -12,7 +12,8 @@ var Refund = Transaction.extend({
         DebitedWalletId: null,
         CreditedWalletId: null,
         RefundReason: null,
-        Reference: null
+        Reference: null,
+        StatementDescriptor: null
     }),
 
     getSubObjects: function() {

--- a/lib/models/Refund.js
+++ b/lib/models/Refund.js
@@ -13,7 +13,7 @@ var Refund = Transaction.extend({
         CreditedWalletId: null,
         RefundReason: null,
         Reference: null,
-        StatementDescriptor: null
+        StatementDescriptor: null 
     }),
 
     getSubObjects: function() {

--- a/typings/enums.d.ts
+++ b/typings/enums.d.ts
@@ -15,6 +15,7 @@ export namespace enums {
         Multibanco: "MULTIBANCO";
         Satispay: "SATISPAY";
         Blik: "BLIK";
+        ApplePay: "APPLEPAY";
         GooglePay: "GOOGLE_PAY";
         Klarna: "KLARNA";
         Ideal: "IDEAL";

--- a/typings/models/payIn.d.ts
+++ b/typings/models/payIn.d.ts
@@ -35,6 +35,7 @@ export namespace payIn {
         | MultibancoWebPayInData
         | SatispayWebPayInData
         | BlikWebPayInData
+        | ApplePayPayInData
         | GooglePayDirectPayInData
         | KlarnaWebPayInData
         | IdealWebPayInData
@@ -1649,6 +1650,90 @@ export namespace payIn {
 
         Fees: MoneyData;
     }
+
+    interface CreateApplePayPayIn {
+        ExecutionType: "DIRECT";
+
+        PaymentType: "APPLE";
+        /**
+         * A user's ID
+         */
+        AuthorId: string;
+
+        /**
+         * The ID of the wallet where money will be credited
+         */
+        CreditedWalletId: string;
+
+        /**
+         * Information about the funds that are being debited
+         */
+        DebitedFunds: MoneyData;
+
+        /**
+         * Information about the fees that were taken by the client for this transaction (and were hence transferred to the Client's platform wallet)
+         */
+        Fees: MoneyData;
+
+        PaymentData: ApplePayPaymentData;
+
+        /**
+         * A custom description to appear on the user's bank statement. It can be up to 10 characters long, and can only include alphanumeric characters or spaces.
+         * See here for important info. Note that each bank handles this information differently, some show less or no information.
+         */
+        StatementDescriptor?: string;
+
+        /**
+         * Custom data that you can add to this item
+         */
+        Tag?: string;
+    }
+    interface ApplePayPayInData extends BasePayInData {
+        ExecutionType: "DIRECT";
+
+        PaymentType: "APPLE";
+        /**
+         * A user's ID
+         */
+        AuthorId: string;
+
+        /**
+         * The ID of the wallet where money will be credited
+         */
+        CreditedWalletId: string;
+
+        /**
+         * Information about the funds that are being debited
+         */
+        DebitedFunds: MoneyData;
+
+        /**
+         * Information about the fees that were taken by the client for this transaction (and were hence transferred to the Client's platform wallet)
+         */
+        Fees: MoneyData;
+
+        PaymentData: ApplePayPaymentData;
+
+        /**
+         * A custom description to appear on the user's bank statement. It can be up to 10 characters long, and can only include alphanumeric characters or spaces.
+         * See here for important info. Note that each bank handles this information differently, some show less or no information.
+         */
+        StatementDescriptor?: string;
+
+        /**
+         * Custom data that you can add to this item
+         */
+        Tag?: string;
+    }
+
+    interface ApplePayPaymentData {
+        TransactionId: string, 
+
+        Network: string,
+
+        TokenData: string
+    }
+
 
     interface CreateGooglePayDirectPayIn {
         ExecutionType: "DIRECT";

--- a/typings/models/refund.d.ts
+++ b/typings/models/refund.d.ts
@@ -77,7 +77,7 @@ export namespace refund {
         /**
          * Custom description to appear on the user’s bank statement along with the platform name
          */
-        StatementDescriptor?: string;
+        StatementDescriptor?: string; 
     }
 
     interface CreateTransferRefund {

--- a/typings/models/refund.d.ts
+++ b/typings/models/refund.d.ts
@@ -46,6 +46,8 @@ export namespace refund {
         DebitedFunds?: MoneyData;
 
         Fees?: MoneyData;
+        
+        StatementDescriptor?: string;
     }
 
     interface CreateTransferRefund {

--- a/typings/services/PayIns.d.ts
+++ b/typings/services/PayIns.d.ts
@@ -22,6 +22,7 @@ export class PayIns {
         MethodOverload<payIn.CreateMultibancoWebPayIn, payIn.MultibancoWebPayInData> &
         MethodOverload<payIn.CreateSatispayWebPayIn, payIn.SatispayWebPayInData> &
         MethodOverload<payIn.CreateBlikWebPayIn, payIn.BlikWebPayInData> &
+        MethodOverload<payIn.CreateApplePayPayIn, payIn.ApplePayPayInData> &
         MethodOverload<payIn.CreateGooglePayDirectPayIn, payIn.GooglePayDirectPayInData> &
         MethodOverload<payIn.CreateKlarnaWebPayIn, payIn.KlarnaWebPayInData> &
         MethodOverload<payIn.CreateIdealWebPayIn, payIn.IdealWebPayInData> &


### PR DESCRIPTION
Hi team,

- `StatmentDescriptor` has been added to Refund 
- ApplePay seems to not have been updated. I added some models and services. Please double check it and amend as needed. Thanks. 