### PR TITLE
Removed chai requirement from Users.js service

### DIFF
--- a/lib/services/Users.js
+++ b/lib/services/Users.js
@@ -30,7 +30,6 @@ var UserNaturalPut = require('../models/UserNaturalPut');
 var CategorizeUserNatural = require('../models/CategorizeUserNatural');
 var CategorizeUserLegal = require('../models/CategorizeUserLegal');
 var UserEnrollmentResult = require('../models/UserEnrollmentResult');
-const {use} = require("chai");
 
 var Users = Service.extend({
     /**


### PR DESCRIPTION
Hello,

It appears chai might have been required by accident: 

Fix https://github.com/Mangopay/mangopay2-nodejs-sdk/issues/442

Please let me know if something else is needed here.